### PR TITLE
bugfix: validators weren't invoked

### DIFF
--- a/Customers.Api/Validation/CreateCustomerRequestValidator.cs
+++ b/Customers.Api/Validation/CreateCustomerRequestValidator.cs
@@ -1,9 +1,10 @@
 ﻿using Customers.Api.Contracts.Requests;
+using FastEndpoints;
 using FluentValidation;
 
 namespace Customers.Api.Validation;
 
-public class CreateCustomerRequestValidator : AbstractValidator<CreateCustomerRequest>
+public class CreateCustomerRequestValidator : Validator<CreateCustomerRequest>
 {
     public CreateCustomerRequestValidator()
     {

--- a/Customers.Api/Validation/UpdateCustomerRequestValidator.cs
+++ b/Customers.Api/Validation/UpdateCustomerRequestValidator.cs
@@ -1,9 +1,10 @@
 ﻿using Customers.Api.Contracts.Requests;
+using FastEndpoints;
 using FluentValidation;
 
 namespace Customers.Api.Validation;
 
-public class UpdateCustomerRequestValidator : AbstractValidator<UpdateCustomerRequest>
+public class UpdateCustomerRequestValidator : Validator<UpdateCustomerRequest>
 {
     public UpdateCustomerRequestValidator()
     {


### PR DESCRIPTION
Followed [documentation](https://fast-endpoints.com/wiki/Validation.html) from FastEndpoints on FluentValidation.